### PR TITLE
Update debian repositories to point to cloudsmith

### DIFF
--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
       - name: Remove uneeded apt repos (that cause issues)
-        run: sudo rm /etc/apt/sources.list.d/yarn*
+        run: sudo rm -rf /etc/apt/sources.list.d/yarn*
 
       - name: Checkout code from Github
         uses: actions/checkout@v2

--- a/tasks/install_rabbit.yml
+++ b/tasks/install_rabbit.yml
@@ -21,14 +21,28 @@
 
 - name: Add RabbitMQ apt repo key
   apt_key:
-    url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
+    url: https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
     state: present
+
+- name: Add RabbitMQ apt repo key
+  apt_key:
+    url: https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key
+    state: present
+
+- name: Remove legacy RabbitMQ apt repo (Debian/Ubuntu)
+  apt_repository:
+    repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
+    state: absent
+    update_cache: yes
 
 - name: Add RabbitMQ apt repo (Debian/Ubuntu)
   apt_repository:
-    repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main"
+    repo: "{{ item }}"
     state: present
     update_cache: yes
+  with_items:
+    - "deb https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_distribution_release }} main"
+    - "deb-src https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_distribution_release }} main"
 
 # See https://stackoverflow.com/questions/32407164/the-vm-is-running-with-native-name-encoding-of-latin1-which-may-cause-elixir-to
 - name: Make sure LC_ALL locale is set to UTF-8


### PR DESCRIPTION
Bintray is being deprecated, so moving to the new official source for this.