### PR TITLE
Use new apt repo and key

### DIFF
--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Real Ansible run
         run: ansible-playbook -i tests/inventory tests/test.yml
 
-      - name: Second run to check for indempotence (allow changes for restarts and rbbit command interactions)
-        run: "ansible-playbook -i tests/inventory tests/test.yml" # | grep -q 'changed=8.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"
+      - name: Second run to check for indempotence (allow few changes for restarts and rbbit command interactions)
+        run: "ansible-playbook -i tests/inventory tests/test.yml | grep -q 'changed=5.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"
 
       - name: Setup serverspec (install gem)
         run: sudo gem install serverspec

--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Real Ansible run
         run: ansible-playbook -i tests/inventory tests/test.yml
 
-      - name: Second run to check for indempotence (allow 7 changes for restarts and rbbit command interactions)
-        run: "ansible-playbook -i tests/inventory tests/test.yml | grep -q 'changed=8.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"
+      - name: Second run to check for indempotence (allow changes for restarts and rbbit command interactions)
+        run: "ansible-playbook -i tests/inventory tests/test.yml" # | grep -q 'changed=8.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"
 
       - name: Setup serverspec (install gem)
         run: sudo gem install serverspec

--- a/tasks/install_rabbit.yml
+++ b/tasks/install_rabbit.yml
@@ -1,7 +1,7 @@
 # Tasks for installing and configuring RabbitMQ and custom plugins on the system
 
 
-# Following guide from https://www.rabbitmq.com/docs/install-debian#apt-quick-start-cloudsmith
+# Following guide from https://www.rabbitmq.com/docs/install-debian#apt-quick-start
 
 - name: Ensure tooling for install is present
   ansible.builtin.apt:
@@ -13,17 +13,9 @@
 
 - name: Add Team RabbitMQs main apt signing key
   ansible.builtin.shell:
-    cmd: curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/com.rabbitmq.team.gpg > /dev/null
+    cmd: curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | sudo gpg --dearmor | sudo tee {{ rabbitmq_team_apt_signing_key_location }} > /dev/null
 
-- name: Add Cloudsmith Erlang repo apt signing key
-  ansible.builtin.shell:
-    cmd: curl -1sLf https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key | sudo gpg --dearmor | sudo tee {{ rabbitmq_cloudsmith_erlang_signing_key_location }} > /dev/null
-
-- name: Add Cloudsmith Rabbit repo apt signing key
-  ansible.builtin.shell:
-    cmd: curl -1sLf https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key | sudo gpg --dearmor | sudo tee {{ rabbitmq_cloudsmith_rabbit_signing_key_location }} > /dev/null
-
-- name: Add RabbitMQ apt repos (erlang + rabbitmq-server cloudsmith repos) by adding sources.list
+- name: Add RabbitMQ apt repos (erlang + rabbitmq-server repos) by adding sources.list
   ansible.builtin.template:
     src: rabbitmq.sources.list.j2
     dest: /etc/apt/sources.list.d/rabbitmq.list

--- a/tasks/install_rabbit.yml
+++ b/tasks/install_rabbit.yml
@@ -13,7 +13,8 @@
 
 - name: Add Team RabbitMQs main apt signing key
   ansible.builtin.shell:
-    cmd: curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | sudo gpg --dearmor | sudo tee {{ rabbitmq_team_apt_signing_key_location }} > /dev/null
+    cmd: curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | gpg --dearmor | tee {{ rabbitmq_team_apt_signing_key_location }} > /dev/null
+    creates: "{{ rabbitmq_team_apt_signing_key_location }}"
 
 - name: Add RabbitMQ apt repos (erlang + rabbitmq-server repos) by adding sources.list
   ansible.builtin.template:

--- a/templates/rabbitmq.sources.list.j2
+++ b/templates/rabbitmq.sources.list.j2
@@ -7,4 +7,4 @@ deb [arch=amd64 signed-by={{ rabbitmq_team_apt_signing_key_location }}] https://
 
 ## Latest RabbitMQ releases
 deb [arch=amd64 signed-by={{ rabbitmq_team_apt_signing_key_location }}] https://deb1.rabbitmq.com/rabbitmq-server/ubuntu/{{ ansible_distribution_release }} {{ ansible_distribution_release }} main
-deb [arch=amd64 signed-by={{ rabbitmq_team_apt_signing_key_location }}] https://deb2.rabbitmq.com/rabbitmq-server/ubuntu/{{ ansible_distribution_release }} {{ ansible_distribution_release }} noble main
+deb [arch=amd64 signed-by={{ rabbitmq_team_apt_signing_key_location }}] https://deb2.rabbitmq.com/rabbitmq-server/ubuntu/{{ ansible_distribution_release }} {{ ansible_distribution_release }} main

--- a/templates/rabbitmq.sources.list.j2
+++ b/templates/rabbitmq.sources.list.j2
@@ -1,20 +1,10 @@
-# Sources list file as suggested by https://www.rabbitmq.com/docs/install-debian#apt-quick-start-cloudsmith
+# Sources list file as suggested by https://www.rabbitmq.com/docs/install-debian#apt-quick-start
 # Make sure keys are installed into expected places first!
 
-## Provides modern Erlang/OTP releases
-##
-deb [arch=amd64 signed-by={{ rabbitmq_cloudsmith_erlang_signing_key_location }}] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_distribution_release }} main
-deb-src [signed-by={{ rabbitmq_cloudsmith_erlang_signing_key_location }}] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_distribution_release }} main
+## Modern Erlang/OTP releases
+deb [arch=amd64 signed-by={{ rabbitmq_team_apt_signing_key_location }}] https://deb1.rabbitmq.com/rabbitmq-erlang/ubuntu/{{ ansible_distribution_release }} {{ ansible_distribution_release }} main
+deb [arch=amd64 signed-by={{ rabbitmq_team_apt_signing_key_location }}] https://deb2.rabbitmq.com/rabbitmq-erlang/ubuntu/{{ ansible_distribution_release }} {{ ansible_distribution_release }} main
 
-# another mirror for redundancy
-deb [arch=amd64 signed-by={{ rabbitmq_cloudsmith_erlang_signing_key_location }}] https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_distribution_release }} main
-deb-src [signed-by={{ rabbitmq_cloudsmith_erlang_signing_key_location }}] https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_distribution_release }} main
-
-## Provides RabbitMQ
-##
-deb [arch=amd64 signed-by={{ rabbitmq_cloudsmith_rabbit_signing_key_location }}] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu {{ ansible_distribution_release }} main
-deb-src [signed-by={{ rabbitmq_cloudsmith_rabbit_signing_key_location }}] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu {{ ansible_distribution_release }} main
-
-# another mirror for redundancy
-deb [arch=amd64 signed-by={{ rabbitmq_cloudsmith_rabbit_signing_key_location }}] https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu {{ ansible_distribution_release }} main
-deb-src [signed-by={{ rabbitmq_cloudsmith_rabbit_signing_key_location }}] https://ppa2.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu {{ ansible_distribution_release }} main
+## Latest RabbitMQ releases
+deb [arch=amd64 signed-by={{ rabbitmq_team_apt_signing_key_location }}] https://deb1.rabbitmq.com/rabbitmq-server/ubuntu/{{ ansible_distribution_release }} {{ ansible_distribution_release }} main
+deb [arch=amd64 signed-by={{ rabbitmq_team_apt_signing_key_location }}] https://deb2.rabbitmq.com/rabbitmq-server/ubuntu/{{ ansible_distribution_release }} {{ ansible_distribution_release }} noble main

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,4 @@
 ---
 # vars file for rabbitmq role
 
-rabbitmq_cloudsmith_erlang_signing_key_location: /usr/share/keyrings/cloudsmith.rabbitmq-erlang.gpg
-rabbitmq_cloudsmith_rabbit_signing_key_location: /usr/share/keyrings/cloudsmith.rabbitmq-server.gpg
+rabbitmq_team_apt_signing_key_location: /usr/share/keyrings/com.rabbitmq.team.gpg


### PR DESCRIPTION
After Rabbit was moved to a new repo last year, see https://www.rabbitmq.com/blog/2025/07/16/debian-apt-repositories-are-moving